### PR TITLE
Fixed source uri's of documents added to index

### DIFF
--- a/cdk/lib/constructs/aws-batch-analysis-construct.ts
+++ b/cdk/lib/constructs/aws-batch-analysis-construct.ts
@@ -77,15 +77,6 @@ export class AwsBatchAnalysisConstruct extends Construct {
           `arn:aws:qbusiness:${cdk.Stack.of(this).region}:${awsAccountId}:application/*`,
         ],
       }));
-      
-      //Grant Job Execution Role access to bedrock
-      jobExecutionRole.addToPolicy(new cdk.aws_iam.PolicyStatement({
-        actions: [
-          "bedrock:InvokeModel"
-        ],
-        resources: ["*"],
-      }));
-
       // Grant Job Execution Role access to logging
       jobExecutionRole.addToPolicy(new cdk.aws_iam.PolicyStatement({
         actions: [

--- a/cdk/lib/constructs/aws-batch-analysis-construct.ts
+++ b/cdk/lib/constructs/aws-batch-analysis-construct.ts
@@ -78,6 +78,14 @@ export class AwsBatchAnalysisConstruct extends Construct {
           `arn:aws:qbusiness:${cdk.Stack.of(this).region}:${awsAccountId}:application/*`,
         ],
       }));
+      
+      //Grant Job Execution Role access to bedrock
+      jobExecutionRole.addToPolicy(new cdk.aws_iam.PolicyStatement({
+        actions: [
+          "bedrock:InvokeModel"
+        ],
+        resources: ["*"],
+      }));
 
       // Grant Job Execution Role access to logging
       jobExecutionRole.addToPolicy(new cdk.aws_iam.PolicyStatement({


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The source uri links weren't follow-able because they didn't have the branch included in the url. I refactored the `processing_files` method to get the branch name, and pass it along to the `upload_prompt_answer_and_file_name` method to be added into the cleaned_file_name.

Testing:
Tested by querying a Q Application trained with the code-analysis tool changes and was able to get this link as a source:
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-fms/blob/master/aws-fms-policy/src/main/java/software/amazon/fms/policy/PolicyHandler.java


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
